### PR TITLE
fix: typo on env.REGISTRY in publish yaml [10029]

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,9 +31,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTER }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build and push docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .


### PR DESCRIPTION
### Description
US: [#10027](https://trello.com/c/Gj1vDa0q)

Summary: As a devops, I want docker images of the application to be released on github

### Changes Made
- Fix: renamed `env.REGISTER` to `env.REGISTRY`

### Related Issues
[Tagging reference #23241294066](https://github.com/LunarMoonDev/user-location/actions/runs/8482303351/job/23241294066)

### Merge Request Checklists
- [ ] I have already updated the sub-task ticket.
- [ ] I have already logged in the sub-task ticket.
- [ ] I have already unit tested these changes.
- [x] I have already prepared deployments scripts.